### PR TITLE
changing window size for between-plane registration

### DIFF
--- a/src/ophys_mfish_dev/ophys/zstack.py
+++ b/src/ophys_mfish_dev/ophys/zstack.py
@@ -885,7 +885,7 @@ def register_within_plane_multi(stack: np.array,
 def reg_between_planes(stack_imgs,
                        ref_ind: int = 30,
                        top_ring_buffer: int = 10,
-                       window_size: int = 1,
+                       window_size: int = 5,
                        use_adapthisteq: bool = True):
     """Register between planes. Each plane with single 2D image
     Use phase correlation.
@@ -901,7 +901,7 @@ def reg_between_planes(stack_imgs,
     top_ring_buffer : int, optional
         number of top lines to skip due to ringing noise, by default 10
     window_size : int, optional
-        window size for rolling, by default 4
+        window size for rolling, by default 5
     use_adapthisteq : bool, optional
         whether to use adaptive histogram equalization, by default True
 

--- a/src/ophys_mfish_dev/ophys/zstack.py
+++ b/src/ophys_mfish_dev/ophys/zstack.py
@@ -204,7 +204,7 @@ def register_cortical_stack(zstack_path: Union[Path, str],
     # 3. Register Zstack
     reg_dicts = []  # Main list to store all results
     reg_ops = {'ref_ind': reference_plane, 'top_ring_buffer': 10,
-               'window_size': 1, 'use_adapthisteq': True}
+               'window_size': 5, 'use_adapthisteq': True}
     
     
     # num channels; not reliable from scanimage metadata, so just look at dims (05/2024)


### PR DESCRIPTION
To improve between-plane registration (2x reg).
It can help reduce shift errors after 2x reg.